### PR TITLE
Fix audio response playback for non-GET requests (Reproduction https://github.com/swagger-api/swagger-ui/pull/10228)

### DIFF
--- a/src/core/components/live-response.jsx
+++ b/src/core/components/live-response.jsx
@@ -109,7 +109,8 @@ export default class LiveResponse extends React.Component {
                           : null
                 }
                 {
-                  body ? <ResponseBody content={ body }
+                  body ? <ResponseBody method={ method }
+                                       content={ body }
                                        contentType={ contentType }
                                        url={ url }
                                        headers={ headers }

--- a/src/core/components/response-body.jsx
+++ b/src/core/components/response-body.jsx
@@ -12,6 +12,7 @@ export default class ResponseBody extends React.PureComponent {
   }
 
   static propTypes = {
+    method: PropTypes.string,
     content: PropTypes.any.isRequired,
     contentType: PropTypes.string,
     getComponent: PropTypes.func.isRequired,
@@ -50,7 +51,7 @@ export default class ResponseBody extends React.PureComponent {
   }
 
   render() {
-    let { content, contentType, url, headers={}, getComponent } = this.props
+    let { method, content, contentType, url, headers={}, getComponent } = this.props
     const { parsedContent } = this.state
     const HighlightCode = getComponent("HighlightCode", true)
     const downloadName = "response_" + new Date().getTime()
@@ -135,6 +136,9 @@ export default class ResponseBody extends React.PureComponent {
 
       // Audio
     } else if (/^audio\//i.test(contentType)) {
+      if (method !== "get") {
+        url = window.URL.createObjectURL(content)
+      }
       bodyEl = <pre className="microlight"><audio controls key={ url }><source src={ url } type={ contentType } /></audio></pre>
     } else if (typeof content === "string") {
       bodyEl = <HighlightCode downloadable fileName={`${downloadName}.txt`} canCopy>{content}</HighlightCode>


### PR DESCRIPTION
Unfortunately, the issue of not being able to play audio for POST requests in Swagger UI doesn't seem to be resolved, so I will personally merge this PR.

Related: https://github.com/swagger-api/swagger-ui/issues/8378, https://github.com/swagger-api/swagger-ui/pull/8398, https://github.com/swagger-api/swagger-ui/pull/10228